### PR TITLE
Style other like buttons

### DIFF
--- a/style/theme.less
+++ b/style/theme.less
@@ -406,6 +406,21 @@
     }
   }
 
+  /* forum thread like heart */
+  .like-wrap.thread .button {
+    .fa-heart {
+      color: #0000;
+      stroke: rgb(var(--color-white));
+      stroke-width: 70;
+    }
+    &.liked {
+      .fa-heart {
+        color: rgb(var(--color-white)) !important;
+        stroke: rgba(0,0,0,0) !important;
+      }
+    }
+  }
+
   /* Scrollbar */
   * {
     scrollbar-color: rgb(var(--color-blue)) rgba(0, 0, 0, 0);

--- a/style/theme.less
+++ b/style/theme.less
@@ -406,14 +406,14 @@
     }
   }
 
-  /* forum thread like heart */
-  .like-wrap.thread .button {
+  /* forum thread, favourite like heart */
+  .like-wrap.thread .button, .actions .favourite {
     .fa-heart {
       color: #0000;
       stroke: rgb(var(--color-white));
       stroke-width: 70;
     }
-    &.liked {
+    &.liked, &.isFavourite {
       .fa-heart {
         color: rgb(var(--color-white)) !important;
         stroke: rgba(0,0,0,0) !important;


### PR DESCRIPTION
changed the style of the thread and favourite like buttons to match the hollow style used in the theme

Before|After
-|-
![](https://files.catbox.moe/z0v9nl.png)|![](https://files.catbox.moe/ea44n0.png)
![](https://files.catbox.moe/3tse5i.png)|![](https://files.catbox.moe/5ht6hb.png)
