### PR TITLE
Remove duplicate tag section on mobile

### DIFF
--- a/style/theme.less
+++ b/style/theme.less
@@ -115,7 +115,7 @@
 		}
 	}
 
-	/* Enable edit button and tags on mobile */
+	/* Enable edit button on mobile */
 	@media screen and (max-width: 760px) {
 		.media.media-page-unscoped .sidebar {
 			display: grid;
@@ -148,15 +148,6 @@
 				margin-bottom: 0;
 			}
 
-			.tags {
-				grid-row: 3;
-
-				margin-top: 0;
-
-				display: flex;
-				flex-direction: column;
-			}
-
 			.rankings {
 				grid-row: 4;
 
@@ -173,14 +164,6 @@
 						grid-column: 2;
 					}
 				}
-			}
-
-			.external-links {
-				grid-row: 5;
-
-				display: flex;
-				flex-direction: column;
-				margin-top: 0;
 			}
 		}
 	}


### PR DESCRIPTION
Anilist had a site update at some point that made tags and external links viewable on mobile, so the current rules end up creating a duplicate section.