### PR TITLE
Fix header colours on character and staff pages

### DIFF
--- a/style/theme.less
+++ b/style/theme.less
@@ -706,10 +706,16 @@
 		}
 	}
 	/* Staff/character page header */
-	.character-wrap .header,
-	.staff-wrap .header {
-		background: rgb(var(--color-foreground));
-
+	.character-wrap > .character > .header,
+	.staff-wrap > .staff > .header {
+		@media screen and (max-width: 700px) {
+			.mobile-background {
+				background: rgb(var(--color-foreground));
+			}
+		}
+		@media screen and (min-width: 701px) {
+			background: rgb(var(--color-foreground));
+		}
 		.name {
 			color: rgb(var(--color-gray-900));
 		}


### PR DESCRIPTION
- Increased selector specificity to fix header colour applying to sub-headers
- Added media query to apply the correct header colour

Before | After
--- | ---
![](https://0x0.st/ofr-.54.png) | ![](https://0x0.st/ofro.20.png)